### PR TITLE
Add missing ITCOIN_SPECIFIC marks

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -6,9 +6,9 @@
 #include <primitives/transaction.h>
 
 #include <consensus/amount.h>
-#include <consensus/validation.h>
+#include <consensus/validation.h> // ITCOIN_SPECIFIC
 #include <hash.h>
-#include <signet.h>
+#include <signet.h> // ITCOIN_SPECIFIC
 #include <tinyformat.h>
 #include <util/strencodings.h>
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1344,7 +1344,7 @@ static const CRPCCommand commands[] =
     { "mining",              &getblocktemplate,        },
     { "mining",              &submitblock,             },
     { "mining",              &submitheader,            },
-    { "mining",              &testblockvalidity,       },
+    { "mining",              &testblockvalidity,       }, // ITCOIN_SPECIFIC
 
 
     { "hidden",              &generatetoaddress,       },

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -23,9 +23,11 @@
 #include <util/system.h>
 #include <uint256.h>
 
+// static constexpr uint8_t SIGNET_HEADER[4] = {0xec, 0xc7, 0xda, 0xa2}; ITCOIN_SPECIFIC: moved to signet.h
+
 static constexpr unsigned int BLOCK_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_NULLDUMMY | SCRIPT_VERIFY_TAPROOT; // ITCOIN_SPECIFIC: added SCRIPT_VERIFY_TAPROOT
 
-bool FetchAndClearCommitmentSection(const Span<const uint8_t> header, CScript& witness_commitment, std::vector<uint8_t>& result)
+bool FetchAndClearCommitmentSection(const Span<const uint8_t> header, CScript& witness_commitment, std::vector<uint8_t>& result) // ITCOIN_SPECIFIC: removed "static", because the function is beng exposed in signet.h
 {
     CScript replacement;
     bool found_header = false;
@@ -52,7 +54,7 @@ bool FetchAndClearCommitmentSection(const Span<const uint8_t> header, CScript& w
     return found_header;
 }
 
-uint256 ComputeModifiedMerkleRoot(const CMutableTransaction& cb, const CBlock& block, bool* mutated)
+uint256 ComputeModifiedMerkleRoot(const CMutableTransaction& cb, const CBlock& block, bool* mutated) // ITCOIN_SPECIFIC: 1. removed "static", because the function is beng exposed in signet.h; 2. added "mutated" output parameter
 {
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
@@ -60,7 +62,7 @@ uint256 ComputeModifiedMerkleRoot(const CMutableTransaction& cb, const CBlock& b
     for (size_t s = 1; s < block.vtx.size(); ++s) {
         leaves[s] = block.vtx[s]->GetHash();
     }
-    return ComputeMerkleRoot(std::move(leaves), mutated);
+    return ComputeMerkleRoot(std::move(leaves), mutated); // ITCOIN_SPECIFIC: added "mutated" parameter
 }
 
 std::optional<SignetTxs> SignetTxs::Create(const CBlock& block, const CScript& challenge)

--- a/src/signet.h
+++ b/src/signet.h
@@ -11,11 +11,11 @@
 
 #include <optional>
 
-constexpr uint8_t SIGNET_HEADER[4] = {0xec, 0xc7, 0xda, 0xa2};
+constexpr uint8_t SIGNET_HEADER[4] = {0xec, 0xc7, 0xda, 0xa2}; // ITCOIN_SPECIFIC: moved from signet.cpp
 
-bool FetchAndClearCommitmentSection(const Span<const uint8_t> header, CScript& witness_commitment, std::vector<uint8_t>& result);
+bool FetchAndClearCommitmentSection(const Span<const uint8_t> header, CScript& witness_commitment, std::vector<uint8_t>& result); // ITCOIN_SPECIFIC: exposed from signet.cpp (it was a static function)
 
-uint256 ComputeModifiedMerkleRoot(const CMutableTransaction& cb, const CBlock& block, bool* mutated = nullptr);
+uint256 ComputeModifiedMerkleRoot(const CMutableTransaction& cb, const CBlock& block, bool* mutated = nullptr); // ITCOIN_SPECIFIC: 1. exposed from signet.cpp (it was a static function); 2. this function has an additional "mutated" output parameter compared to the original bitcoin function
 
 /**
  * Extract signature and check whether a block has a valid solution


### PR DESCRIPTION
The diff between our version and upstream aims to be standardized: every change coming from us should be marked `ITCOIN_SPECIFIC` and include a reference to the previous code contents, in order to ease keeping up with upstream.

This change tags some snippets that were missed out previously. What should be really looked at is the diff of the files involved in this change between **v23.0** and **itcoin** (`hg diff --from v23.0 --to add-missing-itcoin-specific-marks src/signet.* src/primitives/transaction.cpp src/rpc/mining.cpp`).

No functional changes.