### PR TITLE
signet: roll back ComputeModifiedMerkleRoot() to upstream version

### DIFF
--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -54,7 +54,7 @@ bool FetchAndClearCommitmentSection(const Span<const uint8_t> header, CScript& w
     return found_header;
 }
 
-uint256 ComputeModifiedMerkleRoot(const CMutableTransaction& cb, const CBlock& block, bool* mutated) // ITCOIN_SPECIFIC: 1. removed "static", because the function is being exposed in signet.h; 2. added "mutated" output parameter
+static uint256 ComputeModifiedMerkleRoot(const CMutableTransaction& cb, const CBlock& block)
 {
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
@@ -62,7 +62,7 @@ uint256 ComputeModifiedMerkleRoot(const CMutableTransaction& cb, const CBlock& b
     for (size_t s = 1; s < block.vtx.size(); ++s) {
         leaves[s] = block.vtx[s]->GetHash();
     }
-    return ComputeMerkleRoot(std::move(leaves), mutated); // ITCOIN_SPECIFIC: added "mutated" parameter
+    return ComputeMerkleRoot(std::move(leaves));
 }
 
 std::optional<SignetTxs> SignetTxs::Create(const CBlock& block, const CScript& challenge)

--- a/src/signet.h
+++ b/src/signet.h
@@ -15,8 +15,6 @@ constexpr uint8_t SIGNET_HEADER[4] = {0xec, 0xc7, 0xda, 0xa2}; // ITCOIN_SPECIFI
 
 bool FetchAndClearCommitmentSection(const Span<const uint8_t> header, CScript& witness_commitment, std::vector<uint8_t>& result); // ITCOIN_SPECIFIC: exposed from signet.cpp (it was a static function)
 
-uint256 ComputeModifiedMerkleRoot(const CMutableTransaction& cb, const CBlock& block, bool* mutated = nullptr); // ITCOIN_SPECIFIC: 1. exposed from signet.cpp (it was a static function); 2. this function has an additional "mutated" output parameter compared to the original bitcoin function
-
 /**
  * Extract signature and check whether a block has a valid solution
  */


### PR DESCRIPTION
This should have been part of 4e84fe667431, when we stopped using the additional `mutated` parameter in `ComputeModifiedMerkleRoot()`.

This reduces the difference with upstream, with no functional changes, since the code path was already unused.

**Edit**: the series now completely reverts every change we have made to  `ComputeModifiedMerkleRoot()`, since there is no need to invoke the function externally. **The function is now exactly the same as in bitcoin**.
