### PR TITLE
build: remove BOOST_CPPFLAGS from libbitcoinconsensus_la_CPPFLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -779,9 +779,7 @@ libbitcoinconsensus_la_SOURCES = support/cleanse.cpp $(crypto_libbitcoin_crypto_
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
-# ITCOIN_SPECIFIC: BOOST_CPPFLAGS have been added to libbitcoinconsensus_la_CPPFLAGS 
-# Signet module is in libconsensus and requires boost optional
-libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) $(BOOST_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
+libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
 libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -515,9 +515,9 @@ crypto_libbitcoin_crypto_arm_shani_a_CPPFLAGS += -DENABLE_ARM_SHANI
 crypto_libbitcoin_crypto_arm_shani_a_SOURCES = crypto/sha256_arm_shani.cpp
 
 # consensus: shared between all executables that validate any consensus rules.
-# ITCOIN_SPECIFIC, signet is part of consensus in itcoin-core
 libbitcoin_consensus_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_consensus_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+# ITCOIN_SPECIFIC: added signet.h and signet.cpp to libbitcoin_consensus_a_SOURCES. Signet is part of consensus in itcoin-core. The comment was added here because it was not possible to add it in place.
 libbitcoin_consensus_a_SOURCES = \
   arith_uint256.cpp \
   arith_uint256.h \


### PR DESCRIPTION
This PR removes a trick that was needed back when itcoin was based on bitcoin v0.21. In v23 the code base migrated to c++17 and std::optional.

In this way we have one less diff compared with upstream.