### PR TITLE
disable "-werror" while we stay on bitcoin v23.x

### DIFF
--- a/infra/configure-itcoin-core-dev.sh
+++ b/infra/configure-itcoin-core-dev.sh
@@ -62,10 +62,10 @@ cd "${MY_DIR}/.."
     --enable-suppress-external-warnings \
     --enable-tests \
     --enable-wallet \
-    --enable-werror \
     --disable-bench \
     --disable-gui-tests \
     --disable-man \
+    --disable-werror \
     --with-boost="${USR_DIR}" \
     --with-incompatible-bdb \
     --with-zmq \

--- a/infra/configure-itcoin-core.sh
+++ b/infra/configure-itcoin-core.sh
@@ -51,11 +51,11 @@ cd "${MY_DIR}/.."
     --enable-determinism \
     --enable-suppress-external-warnings \
     --enable-wallet \
-    --enable-werror \
     --disable-bench \
     --disable-gui-tests \
     --disable-man \
     --disable-tests \
+    --disable-werror \
     --with-boost="${MY_DIR}/../../itcoin-pbft/build/usrlocal" \
     --with-incompatible-bdb \
     --with-zmq \


### PR DESCRIPTION
Bitcoin **v23.0** generates warnings with gcc 12, and does not copile at all on gcc 13. While the second problem will be solved updating to bitcoin v23.2, the problem of triggering many warnings will not go away while we stay on v23.

This change relaxes the compilation flags in order to tolerate warnings, with the aim of restoring it as soon as we move to a more recent major version.

Without this change it would not be possible, for example, to compile itcoin-core on Fedora 37 (gcc 12).