### PR TITLE
Run & fix shellcheck warnings in the /infra directory

### DIFF
--- a/infra/compute-git-hash.sh
+++ b/infra/compute-git-hash.sh
@@ -35,7 +35,7 @@ elif [ -d "${CANDIDATE_REPO_ROOT}/.hg" ]; then
     # we are in a mercurial repository, let's use mercurial for computing the
     # hash of the current working copy
     REPO_TYPE="hg"
-    GIT_HASH=$(HGPLAIN= hg log --repository "${CANDIDATE_REPO_ROOT}" -r . --template '{gitnode|short}\n')
+    GIT_HASH=$(HGPLAIN="" hg log --repository "${CANDIDATE_REPO_ROOT}" -r . --template '{gitnode|short}\n')
 else
     errecho "ERROR: the directory ${CANDIDATE_REPO_ROOT} does not appear to be a git or mercurial repository"
     exit 1

--- a/infra/configure-itcoin-core-dev.sh
+++ b/infra/configure-itcoin-core-dev.sh
@@ -23,7 +23,7 @@ set -eu
 # https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself#246128
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-if [[ ! -z "${CC-}" ]]; then
+if [[ -n "${CC-}" ]]; then
     # The user requested a custom C compiler. Let's also set CC_FOR_BUILD to the
     # same value, otherwise secp256k1 does not passes the configure step (tested
     # on itcoin v0.21.x, Fedora 36, gcc 12.1).

--- a/infra/configure-itcoin-core.sh
+++ b/infra/configure-itcoin-core.sh
@@ -23,7 +23,7 @@ set -eu
 # https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself#246128
 MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-if [[ ! -z "${CC-}" ]]; then
+if [[ -n "${CC-}" ]]; then
     # The user requested a custom C compiler. Let's also set CC_FOR_BUILD to the
     # same value, otherwise secp256k1 does not passes the configure step (tested
     # on itcoin v0.21.x, Fedora 36, gcc 12.1).

--- a/infra/continue-mining-docker.sh
+++ b/infra/continue-mining-docker.sh
@@ -91,6 +91,16 @@ errecho "Using itcoin docker image ${ITCOIN_IMAGE}"
 # "--publish" parameter fails if the same port is given multiple times.
 # Thus we have to remove duplicates from the set of ZMQ_XXX_PORT variables.
 declare -a ZMQ_PARAMS
+
+# SC2046 shellcheck warning is:
+#
+#     done <<<$(printf '%s\n' "${ZMQ_PUBHASHTX_PORT}" "${ZMQ_PUBRAWBLOCK_PORT}" "${ZMQ_PUBITCOINBLOCK_PORT}" | sort | uniq )
+#             ^-- SC2046 (warning): Quote this to prevent word splitting.
+#
+# But our goal is exactly generating multiple lines via the printf call via word
+# splitting.
+#
+#shellcheck disable=SC2046
 while IFS= read -r ZMQ_PORT; do
     ZMQ_PARAMS+=("--publish" "${ZMQ_PORT}:${ZMQ_PORT}")
 done <<<$(printf '%s\n' "${ZMQ_PUBHASHTX_PORT}" "${ZMQ_PUBRAWBLOCK_PORT}" "${ZMQ_PUBITCOINBLOCK_PORT}" | sort | uniq )

--- a/infra/create-initdata.sh
+++ b/infra/create-initdata.sh
@@ -123,7 +123,7 @@ computeScriptPubKey() {
     SCRIPTPUBKEY=$("${PATH_TO_BINARIES}"/bitcoin-cli -datadir="${TMPDIR}" -regtest getaddressinfo "${TMPADDR}" | jq --raw-output '.scriptPubKey')
     # in our example: 51209a955d04fa1e5819b3e206752793566a1cf14facfbf83b2564fa2a4a4c4daa8b
 
-    echo ${SCRIPTPUBKEY}
+    echo "${SCRIPTPUBKEY}"
 } # computeScriptPubKey()
 
 # Automatically stop the container (wich will also self-remove at script exit
@@ -168,7 +168,7 @@ TR_DESCRIPTORS=$("${PATH_TO_BINARIES}"/bitcoin-cli -datadir="${TMPDIR}" -regtest
 # 1 (the so called "internal chain"). We decide to use the internal chain for
 # coinbase transaction as the miner is sending money to itself, rather than
 # receiving it from third parties.
-TR_CHANGE_DESCRIPTOR=$(echo ${TR_DESCRIPTORS} | jq --raw-output '.[] | select(.desc | contains("/1/*")) | .desc')
+TR_CHANGE_DESCRIPTOR=$(echo "${TR_DESCRIPTORS}" | jq --raw-output '.[] | select(.desc | contains("/1/*")) | .desc')
 # in our example: tr(tprv8ZgxMBicQKsPfP82yMAwmNZaiUkRfQiZgD9qofxjyA7ief44zuyymko2sSeH2E1YPTDjF9XFyGZJkgvVJKoSqtVuY41RoUueHkPNLTfre29/86'/1'/0'/1/*)#z7q0y40v
 {
   read -r BLOCKSCRIPT

--- a/infra/entrypoint.sh
+++ b/infra/entrypoint.sh
@@ -44,6 +44,14 @@ INTERNAL_CONFIG_DIR="/opt/itcoin-core/configdir"
 INTERNAL_DATADIR="/opt/itcoin-core/datadir"
 
 usage() {
+	# The shellcheck warning SC2046 is:
+	#     $(printf "    - %s\n" $(ls -1 /usr/local/bin))
+	#                           ^---------------------^ SC2046 (warning): Quote this to prevent word splitting.
+	#
+	# But in this case we want it to perform word splitting, so that the printf
+	# can generate a bullet list of available commands.
+	#
+	#shellcheck disable=SC2046
 	cat <<-USAGE
 	USAGE:
 

--- a/infra/entrypoint.sh
+++ b/infra/entrypoint.sh
@@ -121,7 +121,6 @@ generateConfigFile() {
 waitForBitcoind() {
 	local TIMEOUT=5
 	local MAX_ATTEMPTS=3
-	local INITIAL_WAIT=1
 
 	local N=0
 	until [ "$N" -ge "${MAX_ATTEMPTS}" ]; do

--- a/infra/initialize-itcoin-docker.sh
+++ b/infra/initialize-itcoin-docker.sh
@@ -99,6 +99,16 @@ mkdir "${EXTERNAL_DATADIR}"
 # "--publish" parameter fails if the same port is given multiple times.
 # Thus we have to remove duplicates from the set of ZMQ_XXX_PORT variables.
 declare -a ZMQ_PARAMS
+
+# SC2046 shellcheck warning is:
+#
+#     done <<<$(printf '%s\n' "${ZMQ_PUBHASHTX_PORT}" "${ZMQ_PUBRAWBLOCK_PORT}" "${ZMQ_PUBITCOINBLOCK_PORT}" | sort | uniq )
+#             ^-- SC2046 (warning): Quote this to prevent word splitting.
+#
+# But our goal is exactly generating multiple lines via the printf call via word
+# splitting.
+#
+#shellcheck disable=SC2046
 while IFS= read -r ZMQ_PORT; do
     ZMQ_PARAMS+=("--publish" "${ZMQ_PORT}:${ZMQ_PORT}")
 done <<<$(printf '%s\n' "${ZMQ_PUBHASHTX_PORT}" "${ZMQ_PUBRAWBLOCK_PORT}" "${ZMQ_PUBITCOINBLOCK_PORT}" | sort | uniq )

--- a/infra/initialize-itcoin-local.sh
+++ b/infra/initialize-itcoin-local.sh
@@ -70,8 +70,9 @@ MINER="${PATH_TO_BINARIES}/miner"
 
 INIT_DATA=$("${MYDIR}/create-initdata.sh")
 
-export BLOCKSCRIPT=$(echo "${INIT_DATA}" | jq --raw-output '.blockscript')
-DESCRIPTORS=$(echo        "${INIT_DATA}" | jq --raw-output '.descriptors')
+BLOCKSCRIPT=$(echo "${INIT_DATA}" | jq --raw-output '.blockscript')
+DESCRIPTORS=$(echo "${INIT_DATA}" | jq --raw-output '.descriptors')
+export BLOCKSCRIPT
 
 errecho "Creating datadir ${DATADIR}. If it already exists this script will fail"
 mkdir "${DATADIR}"

--- a/infra/render-template.sh
+++ b/infra/render-template.sh
@@ -63,6 +63,11 @@ for VAR_NAME in "${@}"; do
 done
 
 # https://unix.stackexchange.com/questions/294378/replacing-only-specific-variables-with-envsubst/294400#294400
+#
+# SC2016 is "Expressions don't expand in single quotes, use double quotes for
+# that" (https://www.shellcheck.net/wiki/SC2016), but we do not want to expand
+# anything here.
+# shellcheck disable=SC2016
 VARIABLES_TO_BE_RENDERED=$(printf '${%s} \n' "${@}")
 
 envsubst "${VARIABLES_TO_BE_RENDERED}" #< bitcoin.conf.tmpl

--- a/infra/render-template.sh
+++ b/infra/render-template.sh
@@ -27,9 +27,6 @@
 
 set -eu
 
-# https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself#246128
-MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 errecho() {
 	# prints to stderr
 	>&2 echo "${@}"

--- a/infra/run-docker-bitcoind.sh
+++ b/infra/run-docker-bitcoind.sh
@@ -75,6 +75,16 @@ errecho "Using itcoin docker image ${ITCOIN_IMAGE}"
 # "--publish" parameter fails if the same port is given multiple times.
 # Thus we have to remove duplicates from the set of ZMQ_XXX_PORT variables.
 declare -a ZMQ_PARAMS
+
+# SC2046 shellcheck warning is:
+#
+#     done <<<$(printf '%s\n' "${ZMQ_PUBHASHTX_PORT}" "${ZMQ_PUBRAWBLOCK_PORT}" "${ZMQ_PUBITCOINBLOCK_PORT}" | sort | uniq )
+#             ^-- SC2046 (warning): Quote this to prevent word splitting.
+#
+# But our goal is exactly generating multiple lines via the printf call via word
+# splitting.
+#
+#shellcheck disable=SC2046
 while IFS= read -r ZMQ_PORT; do
     ZMQ_PARAMS+=("--publish" "${ZMQ_PORT}:${ZMQ_PORT}")
 done <<<$(printf '%s\n' "${ZMQ_PUBHASHTX_PORT}" "${ZMQ_PUBRAWBLOCK_PORT}" "${ZMQ_PUBITCOINBLOCK_PORT}" | sort | uniq )


### PR DESCRIPTION
Before this change, [shellckeck](https://github.com/koalaman/shellcheck) 0.9.0 would complain about 13 potential issues in the scripts in the `/infra` directory.

This PR fixes all of them. In some cases the unusual constructs were deliberate, and thus it was safe to ignore the warnings.

Before:
```
$ shellcheck *sh | grep -E "^In"
In compute-git-hash.sh line 38:
In configure-itcoin-core-dev.sh line 26:
In configure-itcoin-core.sh line 26:
In continue-mining-docker.sh line 96:
In create-initdata.sh line 126:
In create-initdata.sh line 171:
In entrypoint.sh line 55:
In entrypoint.sh line 124:
In initialize-itcoin-docker.sh line 104:
In initialize-itcoin-local.sh line 73:
In render-template.sh line 31:
In render-template.sh line 66:
In run-docker-bitcoind.sh line 80:
```

After:
```
$ shellcheck *sh | grep -E "^In"
[ empty ]
```