### PR TITLE
Fix solution independent blockchain tests

### DIFF
--- a/test/functional/itcoin_feature_solution_independent_blockchain_1_of_2.py
+++ b/test/functional/itcoin_feature_solution_independent_blockchain_1_of_2.py
@@ -92,13 +92,13 @@ class SignetSignatureIndependentMerkleRootTest(BaseItcoinTest):
         self.assert_blockchaininfo_property_forall_nodes("bestblockhash", expected_bestblockhash)
 
         # Check a reorg did not occurr after the partition is resolved
-        assert(expected_bestblockhash == bestblockhash_before_connect)
+        assert_equal(expected_bestblockhash, bestblockhash_before_connect)
 
         #  but they kept the same different coinbase txs
         block3_coinbase_0 = self.nodes[0].getblock(self.nodes[0].getblockhash(3))["tx"][0]
         block3_coinbase_1 = self.nodes[1].getblock(self.nodes[1].getblockhash(3))["tx"][0]
         # The hash of the coinbase should be the same
-        assert(block3_coinbase_0 == block3_coinbase_1)
+        assert_equal(block3_coinbase_0, block3_coinbase_1)
         # The content of the coinbase should be different
         block3_hash = self.nodes[0].getblockhash(3)
         raw_tx_block3_coinbase_0 = self.nodes[0].getrawtransaction(block3_coinbase_0, True, block3_hash)["hex"]
@@ -109,7 +109,7 @@ class SignetSignatureIndependentMerkleRootTest(BaseItcoinTest):
         tx_block3_coinbase_1 = tx_from_hex(raw_tx_block3_coinbase_1)
         tx_block3_coinbase_0.vout[1].scriptPubKey = tx_block3_coinbase_0.vout[1].scriptPubKey[:40]
         tx_block3_coinbase_1.vout[1].scriptPubKey = tx_block3_coinbase_1.vout[1].scriptPubKey[:40]
-        assert( tx_block3_coinbase_0.serialize().hex() == tx_block3_coinbase_1.serialize().hex() )
+        assert_equal(tx_block3_coinbase_0.serialize().hex(), tx_block3_coinbase_1.serialize().hex())
 
         # Mine 4th block
         block = miner.do_generate_next_block(args0)[0]

--- a/test/functional/itcoin_feature_solution_independent_blockchain_1_of_2.py
+++ b/test/functional/itcoin_feature_solution_independent_blockchain_1_of_2.py
@@ -107,8 +107,14 @@ class SignetSignatureIndependentMerkleRootTest(BaseItcoinTest):
         # The content of the coinbase, once excluded the signet solution, should be the same
         tx_block3_coinbase_0 = tx_from_hex(raw_tx_block3_coinbase_0)
         tx_block3_coinbase_1 = tx_from_hex(raw_tx_block3_coinbase_1)
-        tx_block3_coinbase_0.vout[1].scriptPubKey = tx_block3_coinbase_0.vout[1].scriptPubKey[:40]
-        tx_block3_coinbase_1.vout[1].scriptPubKey = tx_block3_coinbase_1.vout[1].scriptPubKey[:40]
+        # To exclude the signet solution, take the first 38 bytes of the 2nd coinbase output
+        #   01 byte contains OP_RETURN (=6a hex) 
+        # + 01 byte contains the size of the PUSH_DATA (=24 hex) 
+        # + 04 bytes contain the WITNESS_COMMITMENT_HEADER (=aa21a9ed hex)
+        # + 32 bytes contain the witness commitment (sha256 of the segwit merkle root)
+        # = 38 bytes
+        tx_block3_coinbase_0.vout[1].scriptPubKey = tx_block3_coinbase_0.vout[1].scriptPubKey[:38]
+        tx_block3_coinbase_1.vout[1].scriptPubKey = tx_block3_coinbase_1.vout[1].scriptPubKey[:38]
         assert_equal(tx_block3_coinbase_0.serialize().hex(), tx_block3_coinbase_1.serialize().hex())
 
         # Mine 4th block

--- a/test/functional/itcoin_feature_solution_independent_blockchain_3_of_4.py
+++ b/test/functional/itcoin_feature_solution_independent_blockchain_3_of_4.py
@@ -93,13 +93,13 @@ class SignetSignatureIndependentMerkleRootTest(BaseItcoinTest):
         self.assert_blockchaininfo_property_forall_nodes("bestblockhash", expected_bestblockhash)
 
         # Check a reorg did not occurr after the partition is resolved
-        assert(expected_bestblockhash == bestblockhash_before_connect)
+        assert_equal(expected_bestblockhash, bestblockhash_before_connect)
 
         #  but they kept the same different coinbase txs
         block3_coinbase_0 = self.nodes[0].getblock(self.nodes[0].getblockhash(3))["tx"][0]
         block3_coinbase_1 = self.nodes[1].getblock(self.nodes[1].getblockhash(3))["tx"][0]
         # The hash of the coinbase should be the same
-        assert(block3_coinbase_0 == block3_coinbase_1)
+        assert_equal(block3_coinbase_0, block3_coinbase_1)
         # The content of the coinbase should be different
         block3_hash = self.nodes[0].getblockhash(3)
         raw_tx_block3_coinbase_0 = self.nodes[0].getrawtransaction(block3_coinbase_0, True, block3_hash)["hex"]
@@ -110,7 +110,7 @@ class SignetSignatureIndependentMerkleRootTest(BaseItcoinTest):
         tx_block3_coinbase_1 = tx_from_hex(raw_tx_block3_coinbase_1)
         tx_block3_coinbase_0.vout[1].scriptPubKey = tx_block3_coinbase_0.vout[1].scriptPubKey[:40]
         tx_block3_coinbase_1.vout[1].scriptPubKey = tx_block3_coinbase_1.vout[1].scriptPubKey[:40]
-        assert( tx_block3_coinbase_0.serialize().hex() == tx_block3_coinbase_1.serialize().hex() )
+        assert_equal(tx_block3_coinbase_0.serialize().hex(), tx_block3_coinbase_1.serialize().hex())
 
         # Mine 4th block
         block = miner.do_generate_next_block(args0)[0]

--- a/test/functional/itcoin_feature_solution_independent_blockchain_3_of_4.py
+++ b/test/functional/itcoin_feature_solution_independent_blockchain_3_of_4.py
@@ -108,8 +108,14 @@ class SignetSignatureIndependentMerkleRootTest(BaseItcoinTest):
         # The content of the coinbase, once excluded the signet solution, should be the same
         tx_block3_coinbase_0 = tx_from_hex(raw_tx_block3_coinbase_0)
         tx_block3_coinbase_1 = tx_from_hex(raw_tx_block3_coinbase_1)
-        tx_block3_coinbase_0.vout[1].scriptPubKey = tx_block3_coinbase_0.vout[1].scriptPubKey[:40]
-        tx_block3_coinbase_1.vout[1].scriptPubKey = tx_block3_coinbase_1.vout[1].scriptPubKey[:40]
+        # To exclude the signet solution, take the first 38 bytes of the 2nd coinbase output
+        #   01 byte contains OP_RETURN (=6a hex) 
+        # + 01 byte contains the size of the PUSH_DATA (=24 hex) 
+        # + 04 bytes contain the WITNESS_COMMITMENT_HEADER (=aa21a9ed hex)
+        # + 32 bytes contain the witness commitment (sha256 of the segwit merkle root)
+        # = 38 bytes
+        tx_block3_coinbase_0.vout[1].scriptPubKey = tx_block3_coinbase_0.vout[1].scriptPubKey[:38]
+        tx_block3_coinbase_1.vout[1].scriptPubKey = tx_block3_coinbase_1.vout[1].scriptPubKey[:38]
         assert_equal(tx_block3_coinbase_0.serialize().hex(), tx_block3_coinbase_1.serialize().hex())
 
         # Mine 4th block


### PR DESCRIPTION
The first commit of this PR fixes #11.

The second commit fixes an error in the "solution independent blockchain" tests (both 1 of 2 and 3 of 4), which was causing the test to erroneously fail when the signet solutions of different coinbase transactions had different sizes. 