### PR TITLE
test: fixes wallet_send.py

### DIFF
--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -407,7 +407,7 @@ class WalletSendTest(BitcoinTestFramework):
         self.log.info("If inputs are specified, do not automatically add more...")
         res = self.test_send(from_wallet=w0, to_wallet=w1, amount=51, inputs=[], add_to_wallet=False)
         assert res["complete"]
-        utxo1 = w0.listunspent()[0]
+        utxo1 = w0.listunspent()[-1] # ITCOIN_SPECIFIC: it was [0], but when COINBASE_MATURITY=0 the most recent UTXO may have a value !=50 causing failure in the next assert_equal
         assert_equal(utxo1["amount"], 50)
         self.test_send(from_wallet=w0, to_wallet=w1, amount=51, inputs=[utxo1],
                        expect_error=(-4, "Insufficient funds"))


### PR DESCRIPTION
This commit is taken from branch `from-23.2-to-24.1-attempt-1` but also applies to v23, and should be merged before the migration.