### PR TITLE
test: fix interface_zmq assertion on initial height

### DIFF
--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -196,7 +196,7 @@ class ZMQTest (BitcoinTestFramework):
         # ITCOIN_SPECIFIC - START
         initial_height = self.nodes[0].getblockchaininfo()['blocks']
         # In this test case, the initial chain is set up with 201 blocks.
-        assert_equal(initial_height, 201)
+        assert_greater_than_or_equal(initial_height, 201)
         timestamp_before_block_generation = int(time.time())
         # ITCOIN_SPECIFIC - END
         self.log.info(f"Generate {num_blocks} blocks (and {num_blocks} coinbase txes)")


### PR DESCRIPTION
Fix an assertion in interface_zmq causing failures in slow systems