### PR TITLE
ci: execute "apt update" before the first "apt install"

### DIFF
--- a/.github/workflows/test-itcoin-core.yml
+++ b/.github/workflows/test-itcoin-core.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - name: Install the build toolchain (gcc-12)
         run: |
+          sudo apt update && \
           sudo apt install --no-install-recommends -y \
               autoconf \
               automake \


### PR DESCRIPTION
Apparently, the base image of the Github CI runner is not updated very often, and does not keep up with the evolving list of mirrors.

The `apt update` was not there on purpose, but maybe it is more pragmatic to just add it.
